### PR TITLE
FIX: Explicitly specify package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,7 @@ description = TODO
 python_requires = >=3.7
 install_requires =
     pydra
-
-packages = find:
+packages = pydra/tasks/TODO
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
`packages = find:` does not seem to work if directories don't have `__init__.py`.