### PR TITLE
FIX: Declare namespace_package in setup.cfg, use dots for packages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,8 @@ test_requires =
     pytest-rerunfailures
     codecov
 
-packages = pydra/tasks/%(subpackage)s
+packages = pydra.tasks.%(subpackage)s
+namespace_packages = pydra.tasks
 
 [options.extras_require]
 doc =


### PR DESCRIPTION
This seems to allow both `pydra` and `pydra-nipype1` to be installed with `-e`. I haven't tested `pydra` with `-e` and `pydra-nipype1` without.