### PR TITLE
FIX: Update namespaces again

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,9 @@ jobs:
       matrix:
         python-version: [3.7, 3.8]
         pip-flags: ['', '--editable']
-        pydra: ['pydra', '--editable git+https://github.com/nipype/pydra.git@0.6.1#egg=pydra']
+        pydra:
+        - 'git+https://github.com/effigies/pydra.git@fix/namespace#egg=pydra'
+        - '--editable git+https://github.com/effigies/pydra.git@fix/namespace#egg=pydra'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -3,6 +3,10 @@
 
 name: Python package
 
+# Set once
+env:
+  SUBPACKAGE: TODO
+
 on:
   push:
     branches: [ master ]
@@ -11,7 +15,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -37,8 +40,8 @@ jobs:
     - name: Install task package
       run: |
         pip install ${{ matrix.pip-flags }} ".[dev]"
-        python -c "import pydra.tasks.TODO as m; print(f'{m.__name__} {m.__version__} @ {m.__file__}')"
+        python -c "import pydra.tasks.$SUBPACKAGE as m; print(f'{m.__name__} {m.__version__} @ {m.__file__}')"
         python -c "import pydra as m; print(f'{m.__name__} {m.__version__} @ {m.__file__}')"
     - name: Test with pytest
       run: |
-        pytest -sv --doctest-modules pydra/tasks/TODO
+        pytest -sv --doctest-modules pydra/tasks/$SUBPACKAGE

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,7 +16,8 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8]
-        pip-flags: ['', '-e']
+        pip-flags: ['', '--editable']
+        pydra: ['pydra', '--editable git+https://github.com/nipype/pydra.git@0.6.1#egg=pydra']
 
     steps:
     - uses: actions/checkout@v2
@@ -27,6 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install ${{ matrix.pydra }}
         pip install ${{ matrix.pip-flags }} ".[dev]"
     - name: Test with pytest
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,11 +25,17 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip
+    - name: Install Pydra
+      run: |
         pip install ${{ matrix.pydra }}
+        python -c "import pydra as m; print(f'{m.__name__} {m.__version__} @ {m.__file__}')"
+    - name: Install task package
+      run: |
         pip install ${{ matrix.pip-flags }} ".[dev]"
+        python -c "import pydra.tasks.TODO as m; print(f'{m.__name__} {m.__version__} @ {m.__file__}')"
     - name: Test with pytest
       run: |
         pytest -sv --doctest-modules pydra/tasks/TODO

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8]
+        pip-flags: ['', '-e']
 
     steps:
     - uses: actions/checkout@v2
@@ -26,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ".[dev]"
+        pip install ${{ matrix.pip-flags }} ".[dev]"
     - name: Test with pytest
       run: |
         pytest -sv --doctest-modules pydra/tasks/TODO

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -36,6 +36,7 @@ jobs:
       run: |
         pip install ${{ matrix.pip-flags }} ".[dev]"
         python -c "import pydra.tasks.TODO as m; print(f'{m.__name__} {m.__version__} @ {m.__file__}')"
+        python -c "import pydra as m; print(f'{m.__name__} {m.__version__} @ {m.__file__}')"
     - name: Test with pytest
       run: |
         pytest -sv --doctest-modules pydra/tasks/TODO

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,8 +21,8 @@ jobs:
         python-version: [3.7, 3.8]
         pip-flags: ['', '--editable']
         pydra:
-        - 'git+https://github.com/effigies/pydra.git@fix/namespace#egg=pydra'
-        - '--editable git+https://github.com/effigies/pydra.git@fix/namespace#egg=pydra'
+        - 'pydra'
+        - '--editable git+https://github.com/nipype/pydra.git#egg=pydra'
 
     steps:
     - uses: actions/checkout@v2

--- a/pydra/tasks/TODO/__init__.py
+++ b/pydra/tasks/TODO/__init__.py
@@ -1,4 +1,8 @@
 """
+This is a basic doctest demonstrating that the package and pydra can both be successfully
+imported.
+
+>>> import pydra.engine
 >>> import pydra.tasks.TODO
 """
 from ._version import get_versions

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ test_requires =
     codecov
 
 packages = pydra.tasks.%(subpackage)s
-namespace_packages = pydra.tasks
 
 [options.extras_require]
 doc =


### PR DESCRIPTION
Starting by ensuring that `pydra.engine` can also be imported.