### PR TITLE
ENH: Add a test subpackage to ensure packages are installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ All tasks will be inserted into the `pydra.tasks.<yourtaskpackagename>` namespac
 1. One of the folders is called TODO. This should also be renamed to your package
    name.
 1. Add tasks to the `pydra/tasks/<yourpackagename>` folder.
+1. An example subpackage is found in `pydra/tasks/<yourpackagename>/utils`.
+   You may wish to add tools to it or delete it.
 1. You may want to initialize a [Sphinx] docs directory.
 1. **Update this README after creating the new repository.**
 

--- a/pydra/tasks/TODO/utils/__init__.py
+++ b/pydra/tasks/TODO/utils/__init__.py
@@ -1,0 +1,6 @@
+"""
+This is a basic doctest demonstrating that subpackags can also be
+imported.
+
+>>> import pydra.tasks.TODO.utils
+"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,6 @@ test_requires =
     pytest-rerunfailures
     codecov
 
-packages = pydra.tasks.%(subpackage)s
-
 [options.extras_require]
 doc =
     packaging

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 import sys
 
-from setuptools import setup
+from setuptools import setup, find_namespace_packages
 import versioneer
+
+SUBPACKAGE = "TODO"
 
 # Give setuptools a hint to complain if it's too old a version
 # 30.3.0 allows us to put most metadata in setup.cfg
@@ -13,8 +15,11 @@ SETUP_REQUIRES += ["wheel"] if "bdist_wheel" in sys.argv else []
 
 if __name__ == "__main__":
     setup(
-        name="pydra-TODO",
+        name=f"pydra-{SUBPACKAGE}",
         setup_requires=SETUP_REQUIRES,
         version=versioneer.get_version(),
         cmdclass=versioneer.get_cmdclass(),
+        packages=find_namespace_packages(
+            include=(f"pydra.tasks.{SUBPACKAGE}", f"pydra.tasks.{SUBPACKAGE}.*")
+        ),
     )


### PR DESCRIPTION
Discovered that the installation of subpackages is broken by default. Seeing if tests can catch it, and then will update the template.